### PR TITLE
Fix environment logging for Unicode systems

### DIFF
--- a/src/rabbit_ct_helpers.erl
+++ b/src/rabbit_ct_helpers.erl
@@ -46,8 +46,14 @@
 
 log_environment() ->
     Vars = lists:sort(fun(A, B) -> A =< B end, os:getenv()),
-    ct:pal(?LOW_IMPORTANCE, "Environment variables:~n~s", [
-        [io_lib:format("  ~s~n", [V]) || V <- Vars]]).
+    case file:native_name_encoding() of
+        latin1 ->
+            ct:pal(?LOW_IMPORTANCE, "Environment variables:~n~s",
+                   [[io_lib:format("  ~s~n", [V]) || V <- Vars]]);
+        utf8 ->
+            ct:pal(?LOW_IMPORTANCE, "Environment variables:~n~ts",
+                   [[io_lib:format("  ~ts~n", [V]) || V <- Vars]])
+    end.
 
 run_setup_steps(Config) ->
     run_setup_steps(Config, []).


### PR DESCRIPTION
When erlang is running in a utf8 enabled mode, os:getenv/0 can return
codepoints greater than 255. In that case printing with `~s` format
modifier will throw an error.

One possible reproduction is something like this (e.g. from management
plugin checkout):

    # move to detached HEAD state
    git checkout origin/stable

    # We'll have current_rmq_ref=(HEAD отделён на f029ad9b)
    LANG=ru_RU.UTF-8 make ct

And this'll result in a `badarg`.