### PR TITLE
Find the rabbitmq.schema in the same way as other schemas

### DIFF
--- a/src/rabbit_ct_config_schema.erl
+++ b/src/rabbit_ct_config_schema.erl
@@ -22,7 +22,8 @@
 
 init_schemas(App, Config) ->
     DepsDir = ?config(erlang_mk_depsdir, Config),
-    RabbitSchema = filename:join([DepsDir, "rabbit", "priv", "schema", "rabbitmq.schema"]),
+    % Note: the schema for the rabbit app is named "rabbitmq.schema"
+    RabbitSchema = find_app_schema(rabbitmq, DepsDir),
     Schemas = case App of
         rabbit -> [RabbitSchema];
         _      -> [RabbitSchema, find_app_schema(App, DepsDir)]


### PR DESCRIPTION
Same issue as #9 when running tests from a clone of `rabbitmq/rabbitmq-server`