### PR TITLE
Revert commit 6a54752c2

### DIFF
--- a/src/rabbit_ct_config_schema.erl
+++ b/src/rabbit_ct_config_schema.erl
@@ -23,7 +23,7 @@
 init_schemas(App, Config) ->
     DepsDir = ?config(erlang_mk_depsdir, Config),
     % Note: the schema for the rabbit app is named "rabbitmq.schema"
-    RabbitSchema = find_app_schema(rabbitmq, DepsDir),
+    RabbitSchema = filename:join([DepsDir, "rabbit", "priv", "schema", "rabbitmq.schema"]),
     Schemas = case App of
         rabbit -> [RabbitSchema];
         _      -> [RabbitSchema, find_app_schema(App, DepsDir)]


### PR DESCRIPTION
Rabbit application doesn't follow naming convention, this change breaks all dependent tests.