### PR TITLE
Remove -Werror as it prevents build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ DEP_PLUGINS = rabbit_common/mk/rabbitmq-build.mk \
 include rabbitmq-components.mk
 include erlang.mk
 
-ERLC_OPTS := $(filter-out -Werror,$(ERLC_OPTS))
+ERLC_OPTS += +nowarn_export_all

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,5 @@ DEP_PLUGINS = rabbit_common/mk/rabbitmq-build.mk \
 
 include rabbitmq-components.mk
 include erlang.mk
+
+ERLC_OPTS := $(filter-out -Werror,$(ERLC_OPTS))


### PR DESCRIPTION
These modules use `export_all` which halts the build due to `-Werror`. It is useful to be able to build this project to add it to the code path for debugging and QA.