### PR TITLE
Compile Erlang/OTP 21

### DIFF
--- a/src/inet_proxy_dist.erl
+++ b/src/inet_proxy_dist.erl
@@ -15,6 +15,10 @@
 %%
 -module(inet_proxy_dist).
 
+%% Transitional step until we can require Erlang/OTP 21 and
+%% use the now recommended try/catch syntax for obtaining the stack trace.
+-compile(nowarn_deprecated_function).
+
 %% A distribution plugin that uses the usual inet_tcp_dist but allows
 %% insertion of a proxy at the receiving end.
 

--- a/src/inet_tcp_proxy.erl
+++ b/src/inet_tcp_proxy.erl
@@ -15,6 +15,10 @@
 %%
 -module(inet_tcp_proxy).
 
+%% Transitional step until we can require Erlang/OTP 21 and
+%% use the now recommended try/catch syntax for obtaining the stack trace.
+-compile(nowarn_deprecated_function).
+
 %% A TCP proxy for insertion into the Erlang distribution mechanism,
 %% which allows us to simulate network partitions.
 


### PR DESCRIPTION
## Proposed Changes

This is one of the PRs that makes RabbitMQ build successfully on Erlang/OTP 21.

OTP 21 deprecated `erlang:get_stacktrace/0` in favor of a new
try/catch syntax. Unfortunately that's not realistic for projects
that support multiple Erlang versions (like us) until OTP 21 can be
the minimum version requirement. In order to compile we have to ignore
the warning. The broad compiler option seems to be the most common
way to support compilation on multiple OTP versions with `warnings_as_errors`: if we use
a function-specific option it will fail on the releases where the function is not deprecated.

## Types of Changes

- [x] Bug fix (non-breaking change related to https://github.com/rabbitmq/rabbitmq-server/issues/1616)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

[#157964874]
