### PR TITLE
Add localhost as SAN to server certificate

### DIFF
--- a/tools/tls-certs/.gitignore
+++ b/tools/tls-certs/.gitignore
@@ -1,0 +1,1 @@
+openssl.cnf

--- a/tools/tls-certs/Makefile
+++ b/tools/tls-certs/Makefile
@@ -5,8 +5,6 @@ endif
 PASSWORD ?= changeme
 HOSTNAME := $(shell if [ "$$(uname)" = Darwin ]; then hostname -s; else hostname; fi)
 
-export HOSTNAME
-
 # Verbosity.
 
 V ?= 0
@@ -45,6 +43,7 @@ $(DIR)/testca/cacert.pem:
 	    chmod 700 private && \
 	    echo 01 > serial && \
 	    :> index.txt && \
+	    sed -e 's/@HOSTNAME@/$(HOSTNAME)/g' $(CURDIR)/openssl.cnf.in > $(CURDIR)/openssl.cnf && \
 	    openssl req -x509 -config $(CURDIR)/openssl.cnf -newkey rsa:2048 -days 365 \
 	      -out cacert.pem -outform PEM -subj /CN=MyTestCA/L=$$$$/ -nodes && \
 	    openssl x509 -in cacert.pem -out cacert.cer -outform DER ) $(openssl_output) \
@@ -53,16 +52,17 @@ $(DIR)/testca/cacert.pem:
 $(DIR)/%/cert.pem: $(DIR)/testca/cacert.pem
 	$(gen_verbose) mkdir -p $(DIR)/$(TARGET)
 	$(verbose) { ( cd $(DIR)/$(TARGET) && \
-	    openssl genrsa -out key.pem 2048 &&\
-	    openssl req -new -key key.pem -out req.pem -outform PEM\
-		-subj /C=UK/ST=England/CN=$(HOSTNAME)/O=$(TARGET)/L=$$$$/ -nodes &&\
+	    openssl genrsa -out key.pem 2048 && \
+	    openssl req -new -key key.pem -out req.pem -outform PEM \
+	      -subj /C=UK/ST=England/CN=$(HOSTNAME)/O=$(TARGET)/L=$$$$/ -nodes && \
 	    cd ../testca && \
+	    sed -e 's/@HOSTNAME@/$(HOSTNAME)/g' $(CURDIR)/openssl.cnf.in > $(CURDIR)/openssl.cnf && \
 	    openssl ca -config $(CURDIR)/openssl.cnf -in ../$(TARGET)/req.pem -out \
 	      ../$(TARGET)/cert.pem -notext -batch -extensions \
 	      $(TARGET)_ca_extensions && \
 	    cd ../$(TARGET) && \
 	    openssl pkcs12 -export -out keycert.p12 -in cert.pem -inkey key.pem \
-	    -passout pass:$(PASSWORD) ) $(openssl_output) || (rm -rf $(DIR)/$(TARGET) && false); }
+	      -passout pass:$(PASSWORD) ) $(openssl_output) || (rm -rf $(DIR)/$(TARGET) && false); }
 
 clean:
 	rm -rf $(DIR)/testca

--- a/tools/tls-certs/Makefile
+++ b/tools/tls-certs/Makefile
@@ -5,6 +5,8 @@ endif
 PASSWORD ?= changeme
 HOSTNAME := $(shell if [ "$$(uname)" = Darwin ]; then hostname -s; else hostname; fi)
 
+export HOSTNAME
+
 # Verbosity.
 
 V ?= 0

--- a/tools/tls-certs/openssl.cnf
+++ b/tools/tls-certs/openssl.cnf
@@ -1,3 +1,6 @@
+HOSTNAME=localhost
+hostname=$ENV::HOSTNAME
+
 [ ca ]
 default_ca = testca
 
@@ -58,4 +61,5 @@ extendedKeyUsage = 1.3.6.1.5.5.7.3.1
 subjectAltName   = @server_alt_names
 
 [ server_alt_names ]
-DNS.1 = localhost
+DNS.1 = $hostname
+DNS.2 = localhost

--- a/tools/tls-certs/openssl.cnf
+++ b/tools/tls-certs/openssl.cnf
@@ -55,3 +55,7 @@ extendedKeyUsage = 1.3.6.1.5.5.7.3.2
 basicConstraints = CA:false
 keyUsage         = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.1
+subjectAltName   = @server_alt_names
+
+[ server_alt_names ]
+DNS.1 = localhost

--- a/tools/tls-certs/openssl.cnf.in
+++ b/tools/tls-certs/openssl.cnf.in
@@ -1,6 +1,3 @@
-HOSTNAME=localhost
-hostname=$ENV::HOSTNAME
-
 [ ca ]
 default_ca = testca
 
@@ -61,5 +58,5 @@ extendedKeyUsage = 1.3.6.1.5.5.7.3.1
 subjectAltName   = @server_alt_names
 
 [ server_alt_names ]
-DNS.1 = $hostname
+DNS.1 = @HOSTNAME@
 DNS.2 = localhost


### PR DESCRIPTION
This helps for Java client hostname verification tests on CI: the CI
containers resolve the hostname to an external IP address and the broker
doesn't accept the connection for guest because it's not from localhost.
By using localhost in the server certificate SAN, hostname verification
is enforced and the connection is from localhost.