### PR TITLE
URL Cleanup

### DIFF
--- a/tools/terraform/direct-vms/templates/setup-erlang.sh
+++ b/tools/terraform/direct-vms/templates/setup-erlang.sh
@@ -66,7 +66,7 @@ esac
 setup_backports() {
   # Enable backports.
   cat >/etc/apt/sources.list.d/backports.list << EOF
-deb http://httpredir.debian.org/debian $debian_codename-backports main
+deb http://cdn-fastly.deb.debian.org/debian $debian_codename-backports main
 EOF
   apt-get -qq update
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://httpredir.debian.org/debian (302) could not be migrated:  
   ([https](https://httpredir.debian.org/debian) result AnnotatedConnectException).