### PR TITLE
rabbit_ct_broker_helpers: Limit Erlang VM to two schedulers

### DIFF
--- a/src/rabbit_ct_broker_helpers.erl
+++ b/src/rabbit_ct_broker_helpers.erl
@@ -652,7 +652,7 @@ do_start_rabbitmq_node(Config, NodeConfig, I) ->
       {"RABBITMQ_DIST_PORT=~b", [DistPort]},
       {"RABBITMQ_CONFIG_FILE=~s", [ConfigFile]},
       {"RABBITMQ_SERVER_START_ARGS=~s", [StartArgs1]},
-      "RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=+S 2 +sbwt very_short",
+      "RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=+S 2 +sbwt very_short +A 24",
       {"TEST_TMPDIR=~s", [PrivDir]}
       | ExtraArgs],
     case rabbit_ct_helpers:make(Config, SrcDir, Cmd) of

--- a/src/rabbit_ct_broker_helpers.erl
+++ b/src/rabbit_ct_broker_helpers.erl
@@ -652,6 +652,7 @@ do_start_rabbitmq_node(Config, NodeConfig, I) ->
       {"RABBITMQ_DIST_PORT=~b", [DistPort]},
       {"RABBITMQ_CONFIG_FILE=~s", [ConfigFile]},
       {"RABBITMQ_SERVER_START_ARGS=~s", [StartArgs1]},
+      "RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=+S 2 +sbwt very_short",
       {"TEST_TMPDIR=~s", [PrivDir]}
       | ExtraArgs],
     case rabbit_ct_helpers:make(Config, SrcDir, Cmd) of


### PR DESCRIPTION
The idea is to reduce the load when testing RabbitMQ. It is especially useful in CI where we might run multiple testsuites in parallel in different containers.

The value of "2" is currently hard-coded.

At the same time, we change the "scheduler busy wait time" parameter to "very_short" so thay unused schedulers are put to sleep quickly.

Discussed with: @michaelklishin @gerhard