### PR TITLE
Do not use deprecated configuration value

### DIFF
--- a/src/rabbit_ct_broker_helpers.erl
+++ b/src/rabbit_ct_broker_helpers.erl
@@ -462,7 +462,7 @@ update_tcp_ports_in_rmq_config(NodeConfig, [tcp_port_amqp_tls = Key | Rest]) ->
     update_tcp_ports_in_rmq_config(NodeConfig1, Rest);
 update_tcp_ports_in_rmq_config(NodeConfig, [tcp_port_mgmt = Key | Rest]) ->
     NodeConfig1 = rabbit_ct_helpers:merge_app_env(NodeConfig,
-      {rabbitmq_management, [{listener, [{port, ?config(Key, NodeConfig)}]}]}),
+      {rabbitmq_management, [{tcp_config, [{port, ?config(Key, NodeConfig)}]}]}),
     update_tcp_ports_in_rmq_config(NodeConfig1, Rest);
 update_tcp_ports_in_rmq_config(NodeConfig, [tcp_port_mqtt = Key | Rest]) ->
     NodeConfig1 = rabbit_ct_helpers:merge_app_env(NodeConfig,


### PR DESCRIPTION
`listener` is deprecated, use `tcp_config` instead.

See rabbitmq/rabbitmq-management-exchange#8 as well