### PR TITLE
Adapt to rabbitmq-server(8) move to Erlang code

### DIFF
--- a/src/rabbit_ct_broker_helpers.erl
+++ b/src/rabbit_ct_broker_helpers.erl
@@ -175,10 +175,10 @@
 
 setup_steps() ->
     [
+      fun run_make_dist/1,
       fun rabbit_ct_helpers:ensure_rabbitmqctl_cmd/1,
       fun rabbit_ct_helpers:ensure_rabbitmqctl_app/1,
       fun rabbit_ct_helpers:ensure_rabbitmq_plugins_cmd/1,
-      fun run_make_dist/1,
       fun set_lager_flood_limit/1,
       fun start_rabbitmq_nodes/1,
       fun share_dist_and_proxy_ports_map/1

--- a/src/rabbit_ct_broker_helpers.erl
+++ b/src/rabbit_ct_broker_helpers.erl
@@ -674,6 +674,7 @@ do_start_rabbitmq_node(Config, NodeConfig, I) ->
       {"RABBITMQ_CONFIG_FILE=~s", [ConfigFile]},
       {"RABBITMQ_SERVER_START_ARGS=~s", [StartArgs1]},
       "RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=+S 2 +sbwt very_short +A 24",
+      "RABBITMQ_LOG=debug",
       {"TEST_TMPDIR=~s", [PrivDir]}
       | ExtraArgs],
     case rabbit_ct_helpers:make(Config, SrcDir, Cmd) of

--- a/src/rabbit_ct_broker_helpers.erl
+++ b/src/rabbit_ct_broker_helpers.erl
@@ -637,13 +637,25 @@ do_start_rabbitmq_node(Config, NodeConfig, I) ->
                     true ->
                         DepsDir = ?config(erlang_mk_depsdir, Config),
                         ErlLibs = os:getenv("ERL_LIBS"),
-                        SecDepsDir = ?config(secondary_erlang_mk_depsdir, Config),
+                        SecDepsDir = ?config(secondary_erlang_mk_depsdir,
+                                             Config),
                         SecErlLibs = lists:flatten(
                                        string:replace(ErlLibs,
                                                       DepsDir,
                                                       SecDepsDir,
                                                       all)),
-                        SecScriptsDir = filename:join([SecDepsDir, "rabbit", "scripts"]),
+                        SecNewScriptsDir = filename:join([SecDepsDir,
+                                                          SrcDir,
+                                                          "sbin"]),
+                        SecOldScriptsDir = filename:join([SecDepsDir,
+                                                          "rabbit",
+                                                          "scripts"]),
+                        SecNewScriptsDirExists = filelib:is_dir(
+                                                   SecNewScriptsDir),
+                        SecScriptsDir = case SecNewScriptsDirExists of
+                                            true  -> SecNewScriptsDir;
+                                            false -> SecOldScriptsDir
+                                        end,
                         [{"DEPS_DIR=~s", [SecDepsDir]},
                          {"REBAR_DEPS_DIR=~s", [SecDepsDir]},
                          {"ERL_LIBS=~s", [SecErlLibs]},

--- a/src/rabbit_ct_broker_helpers.erl
+++ b/src/rabbit_ct_broker_helpers.erl
@@ -633,6 +633,12 @@ do_start_rabbitmq_node(Config, NodeConfig, I) ->
                      true -> ["LEAVE_PLUGINS_DISABLED=yes" | ExtraArgs1];
                      _    -> ExtraArgs1
                  end,
+    KeepPidFile = rabbit_ct_helpers:get_config(
+                    Config, keep_pid_file_on_exit),
+    ExtraArgs3 = case KeepPidFile of
+                     true -> ["RABBITMQ_KEEP_PID_FILE_ON_EXIT=yes" | ExtraArgs2];
+                     _    -> ExtraArgs2
+                 end,
     ExtraArgs = case UseSecondaryUmbrella of
                     true ->
                         DepsDir = ?config(erlang_mk_depsdir, Config),
@@ -663,9 +669,9 @@ do_start_rabbitmq_node(Config, NodeConfig, I) ->
                          {"RABBITMQ_SERVER=~s/rabbitmq-server", [SecScriptsDir]},
                          {"RABBITMQCTL=~s/rabbitmqctl", [SecScriptsDir]},
                          {"RABBITMQ_PLUGINS=~s/rabbitmq-plugins", [SecScriptsDir]}
-                         | ExtraArgs2];
+                         | ExtraArgs3];
                     false ->
-                        ExtraArgs2
+                        ExtraArgs3
                 end,
     Cmd = ["start-background-broker",
       {"RABBITMQ_NODENAME=~s", [Nodename]},

--- a/src/rabbit_ct_broker_helpers.erl
+++ b/src/rabbit_ct_broker_helpers.erl
@@ -681,6 +681,7 @@ do_start_rabbitmq_node(Config, NodeConfig, I) ->
       {"RABBITMQ_SERVER_START_ARGS=~s", [StartArgs1]},
       "RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=+S 2 +sbwt very_short +A 24",
       "RABBITMQ_LOG=debug",
+      "RMQCTL_WAIT_TIMEOUT=180",
       {"TEST_TMPDIR=~s", [PrivDir]}
       | ExtraArgs],
     case rabbit_ct_helpers:make(Config, SrcDir, Cmd) of

--- a/src/rabbit_ct_broker_helpers.erl
+++ b/src/rabbit_ct_broker_helpers.erl
@@ -959,6 +959,7 @@ rabbitmqctl(Config, Node, Args) ->
     NodeConfig = get_node_config(Config, Node),
     Nodename = ?config(nodename, NodeConfig),
     Env0 = [
+      {"RABBITMQ_SCRIPTS_DIR", filename:dirname(Rabbitmqctl)},
       {"RABBITMQ_PID_FILE", ?config(pid_file, NodeConfig)},
       {"RABBITMQ_MNESIA_DIR", ?config(mnesia_dir, NodeConfig)},
       {"RABBITMQ_PLUGINS_DIR", ?config(plugins_dir, NodeConfig)},
@@ -989,6 +990,7 @@ rabbitmq_queues(Config, Node, Args) ->
     NodeConfig = rabbit_ct_broker_helpers:get_node_config(Config, Node),
     Nodename = ?config(nodename, NodeConfig),
     Env0 = [
+      {"RABBITMQ_SCRIPTS_DIR", filename:dirname(RabbitmqQueues)},
       {"RABBITMQ_PID_FILE", ?config(pid_file, NodeConfig)},
       {"RABBITMQ_MNESIA_DIR", ?config(mnesia_dir, NodeConfig)},
       {"RABBITMQ_PLUGINS_DIR", ?config(plugins_dir, NodeConfig)},
@@ -1639,6 +1641,7 @@ plugin_action(Config, Node, Args) ->
     NodeConfig = get_node_config(Config, Node),
     Nodename = ?config(nodename, NodeConfig),
     Env = [
+      {"RABBITMQ_SCRIPTS_DIR", filename:dirname(Rabbitmqplugins)},
       {"RABBITMQ_PID_FILE", ?config(pid_file, NodeConfig)},
       {"RABBITMQ_MNESIA_DIR", ?config(mnesia_dir, NodeConfig)},
       {"RABBITMQ_PLUGINS_DIR", ?config(plugins_dir, NodeConfig)},

--- a/src/rabbit_ct_helpers.erl
+++ b/src/rabbit_ct_helpers.erl
@@ -367,7 +367,10 @@ ensure_rabbitmqctl_cmd(Config) ->
             Error;
         _ ->
             Cmd = [Rabbitmqctl],
-            case exec(Cmd, [drop_stdout]) of
+            Env = [
+                   {"RABBITMQ_SCRIPTS_DIR", filename:dirname(Rabbitmqctl)}
+                  ],
+            case exec(Cmd, [drop_stdout, {env, Env}]) of
                 {error, 64, _} ->
                     set_config(Config, {rabbitmqctl_cmd, Rabbitmqctl});
                 {error, Code, Reason} ->
@@ -440,7 +443,10 @@ ensure_rabbitmq_plugins_cmd(Config) ->
             Error;
         _ ->
             Cmd = [Rabbitmqplugins],
-            case exec(Cmd, [drop_stdout]) of
+            Env = [
+                   {"RABBITMQ_SCRIPTS_DIR", filename:dirname(Rabbitmqplugins)}
+                  ],
+            case exec(Cmd, [drop_stdout, {env, Env}]) of
                 {error, 64, _} ->
                     set_config(Config, {rabbitmq_plugins_cmd, Rabbitmqplugins});
                 _ ->
@@ -464,7 +470,10 @@ ensure_rabbitmq_queues_cmd(Config) ->
             Error;
         _ ->
             Cmd = [RabbitmqQueues],
-            case exec(Cmd, [drop_stdout]) of
+            Env = [
+                   {"RABBITMQ_SCRIPTS_DIR", filename:dirname(RabbitmqQueues)}
+                  ],
+            case exec(Cmd, [drop_stdout, {env, Env}]) of
                 {error, 64, _} ->
                     set_config(Config,
                                {rabbitmq_queues_cmd,


### PR DESCRIPTION
This pull request is part of the effort to move rabbitmq-server(8) scripts to Erlang code and transform the `rabbit` application in a regular Erlang/OTP application (rabbitmq/rabbitmq-server#2180).

This patch's main part adapts rabbitmq-ct-helpers to the changes following rabbitmq/rabbitmq-server#2180: CLI tools are expected to be local to the tested project.