### PR TITLE
Add function head to get static content

### DIFF
--- a/src/rabbit_mgmt_test_util.erl
+++ b/src/rabbit_mgmt_test_util.erl
@@ -96,6 +96,8 @@ assert_permanent_redirect(Config, Path, ExpectedLocation) ->
 req(Config, Type, Path, Headers) ->
     req(Config, 0, Type, Path, Headers).
 
+req(Config, Node, get_static, Path, Headers) ->
+    httpc:request(get, {uri_base_from(Config, Node, "") ++ Path, Headers}, ?HTTPC_OPTS, []);
 req(Config, Node, Type, Path, Headers) ->
     httpc:request(Type, {uri_base_from(Config, Node) ++ Path, Headers}, ?HTTPC_OPTS, []).
 


### PR DESCRIPTION
By specifying `get_static` as the `Type` the `api/` part of the URI will not be added.

Part of rabbitmq/rabbitmq-management#767