### PR TITLE
Extend broker helpers for 'per user-limits' testing

### DIFF
--- a/src/rabbit_ct_broker_helpers.erl
+++ b/src/rabbit_ct_broker_helpers.erl
@@ -136,6 +136,11 @@
 
     set_vhost_limit/5,
 
+    set_user_limits/3,
+    set_user_limits/4,
+    clear_user_limits/3,
+    clear_user_limits/4,
+
     enable_plugin/3,
     disable_plugin/3,
 
@@ -1335,6 +1340,39 @@ set_vhost_limit(Config, Node, VHost, Limit0, Value) ->
         rabbit_vhost_limit,
         set,
         [VHost, Definition, <<"ct-tests">>]).
+
+set_user_limits(Config, Username, Limits) ->
+    set_user_limits(Config, 0, Username, Limits).
+
+set_user_limits(Config, Node, Username, Limits0) when is_map(Limits0) ->
+    Limits =
+        maps:fold(fun(Limit0, Val, Acc) ->
+                      Limit = case Limit0 of
+                          max_connections -> <<"max-connections">>;
+                          max_channels    -> <<"max-channels">>;
+                          Other -> rabbit_data_coercion:to_binary(Other)
+                      end,
+                      maps:merge(#{Limit => Val}, Acc)
+                  end, #{}, Limits0),
+    rpc(Config, Node,
+        rabbit_auth_backend_internal,
+        set_user_limits,
+        [Username, Limits, <<"ct-tests">>]).
+
+clear_user_limits(Config, Username, Limit) ->
+    clear_user_limits(Config, 0, Username, Limit).
+
+clear_user_limits(Config, Node, Username, Limit0) ->
+    Limit = case Limit0 of
+      all             -> <<"all">>;
+      max_connections -> <<"max-connections">>;
+      max_channels    -> <<"max-channels">>;
+      Other -> rabbit_data_coercion:to_binary(Other)
+    end,
+    rpc(Config, Node,
+        rabbit_auth_backend_internal,
+        clear_user_limits,
+        [Username, Limit, <<"ct-tests">>]).
 
 %% Functions to execute code on a remote node/broker.
 

--- a/src/rabbit_ct_broker_helpers.erl
+++ b/src/rabbit_ct_broker_helpers.erl
@@ -52,6 +52,9 @@
     reset_node/2,
     force_reset_node/2,
 
+    forget_cluster_node/3,
+    forget_cluster_node/4,
+
     cluster_members_online/2,
 
     is_feature_flag_supported/2,
@@ -1515,6 +1518,14 @@ reset_node(Config, Node) ->
 force_reset_node(Config, Node) ->
     Name = rabbit_ct_broker_helpers:get_node_config(Config, Node, nodename),
     rabbit_control_helper:command(force_reset, Name).
+
+forget_cluster_node(Config, Node, NodeToForget) ->
+    forget_cluster_node(Config, Node, NodeToForget, []).
+forget_cluster_node(Config, Node, NodeToForget, Opts) ->
+    Name = rabbit_ct_broker_helpers:get_node_config(Config, Node, nodename),
+    NameToForget =
+        rabbit_ct_broker_helpers:get_node_config(Config, NodeToForget, nodename),
+    rabbit_control_helper:command(forget_cluster_node, Name, [NameToForget], Opts).
 
 is_feature_flag_supported(Config, FeatureName) ->
     Nodes = rabbit_ct_broker_helpers:get_node_configs(Config, nodename),


### PR DESCRIPTION
Part of: https://github.com/rabbitmq/rabbitmq-server/pull/2380

**This work has be carried out by** [Erlang Solutions](https://www.erlang-solutions.com/) **and sponsored by** [CloudAMQP](https://www.cloudamqp.com/)