### PR TITLE
Add ?awaitMatch macro

### DIFF
--- a/include/rabbit_assert.hrl
+++ b/include/rabbit_assert.hrl
@@ -1,0 +1,21 @@
+-define(awaitMatch(Guard, Expr, Timeout),
+        begin
+            ((fun Filter(Horizon) ->
+                      R = Expr,
+                      case (R) of
+                          Guard -> R;
+                          __V -> case erlang:system_time(millisecond) of
+                                     Now when Now < Horizon ->
+                                         timer:sleep(min(50, Horizon - Now)),
+                                         Filter(Horizon);
+                                     _ ->
+                                         erlang:error({awaitMatch,
+                                                       [{module, ?MODULE},
+                                                        {line, ?LINE},
+                                                        {expression, (??Expr)},
+                                                        {pattern, (??Guard)},
+                                                        {value, __V}]})
+                                 end
+                      end
+              end)(erlang:system_time(millisecond) + Timeout))
+        end).

--- a/src/rabbit_ct_proper_helpers.erl
+++ b/src/rabbit_ct_proper_helpers.erl
@@ -20,8 +20,7 @@
 -export([run_proper/3]).
 
 run_proper(Fun, Args, NumTests) ->
-    ?assertEqual(
-       true,
+    ?assert(
        proper:counterexample(erlang:apply(Fun, Args),
 			     [{numtests, NumTests},
 			      {on_output, fun(".", _) -> ok; % don't print the '.'s on new lines


### PR DESCRIPTION
`?awaitMatch(Guard, Expr, Timeout)` reevaluates `Expr` until it matches
`Guard` up to `Timeout` milliseconds from now. It returns the matched
value, in the event said value is useful later in a test.

Also simplify an instance of `?assertEqual(true, ...` to `?assert(`