### PR TITLE
Use elixir itself to find its lib directory

### DIFF
--- a/src/rabbit_ct_helpers.erl
+++ b/src/rabbit_ct_helpers.erl
@@ -660,31 +660,9 @@ find_elixir_home() ->
                 end,
     case os:find_executable(ElixirExe) of
         false   -> {skip, "Failed to locate Elixir executable"};
-        ExePath -> resolve_symlink(ExePath)
-    end.
-
-resolve_symlink(ExePath) ->
-    case file:read_link_all(ExePath) of
-        {error, einval} ->
-            determine_elixir_home(ExePath);
-        {ok, ResolvedLink} ->
-            ExePath1 = filename:absname(ResolvedLink,
-                                        filename:dirname(ExePath)),
-            resolve_symlink(ExePath1);
-        {error, Reason} ->
-            Msg = rabbit_misc:format("Failed to locate Elixir home: ~p",
-                                     [file:format_error(Reason)]),
-            {skip, Msg}
-    end.
-
-determine_elixir_home(ExePath) ->
-    LibPath = filename:join([filename:dirname(filename:dirname(ExePath)),
-                             "lib",
-                             "elixir",
-                             "ebin"]),
-    case filelib:is_dir(LibPath) of
-        true  -> LibPath;
-        false -> {skip, "Failed to locate Elixir lib dir"}
+        ExePath ->
+            {ok, ElixirLibDir} = exec([ExePath, "--eval", "IO.write(:code.lib_dir(:elixir, :ebin))"], []),
+            ElixirLibDir
     end.
 
 stop_long_running_testsuite_monitor(Config) ->


### PR DESCRIPTION
This removes all the guesswork from the process. E.g. the old version was not working with elixir from nixpkgs/NixOS.